### PR TITLE
Fix notification on Android 8.0+ devices.

### DIFF
--- a/hooks/moodle.py
+++ b/hooks/moodle.py
@@ -73,8 +73,11 @@ def process_pushnotification_payload(data):
                 "usertoid": usertoid,
                 "courseid": courseid,
                 "notificationtype": notificationtype,
-                "moduleid": moduleid
-            }
+                "moduleid": moduleid,
+                "android_channel_id": "PushPluginChannel",
+                "notId": str(random.randint(1, 1000000))
+            },
+            "priority": "high",
         },
         "apns": {
             "payload": {


### PR DESCRIPTION
Assign each notification a unique Id so that they can't override in
notification tray.